### PR TITLE
proxy mopidy frontend on port 80 via haproxy

### DIFF
--- a/Dockerbin/haproxy.cfg
+++ b/Dockerbin/haproxy.cfg
@@ -1,0 +1,34 @@
+global
+        maxconn 4096
+        user haproxy
+        group haproxy
+        daemon
+        log 127.0.0.1 local0 debug
+
+defaults
+        log     global
+        mode    http
+        option  httplog
+        option  dontlognull
+        retries 3
+        option redispatch
+        option http-server-close
+        option forwardfor
+        maxconn 2000
+        timeout connect 5s
+        timeout client  15min
+        timeout server  15min
+
+frontend public
+        bind *:80
+        use_backend mopidympd if { path_beg /mpd/ }
+        default_backend mopidyhttp
+
+backend mopidyhttp
+        reqrep ^([^\ :]*)\ /(.*)     \1\ /\2
+        option forwardfor
+        server mopidyhttp1 127.0.0.1:8080
+
+backend mopidympd
+        reqrep ^([^\ :]*)\ /mpd/(.*)     \1\ /\2
+        server mopidympd1  127.0.0.1:6680

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -8,7 +8,7 @@ RUN apt-get update && apt-get install -y \
 # Add Mopidy sources
 RUN wget -q -O - https://apt.mopidy.com/mopidy.gpg | apt-key add - && wget -q -O /etc/apt/sources.list.d/mopidy.list https://apt.mopidy.com/jessie.list
 
-# WTF is going on with httpredir from debian? removing it the dirty way
+# debian httpredir mirror proxy often ends up with 404s - editing source file to avoid it
 RUN sed -i "s/httpredir.debian.org/`curl -s -D - http://httpredir.debian.org/demo/debian/ | awk '/^Link:/ { print $2 }' | sed -e 's@<http://\(.*\)/debian/>;@\1@g'`/" /etc/apt/sources.list
 
 # Install apt deps
@@ -31,8 +31,12 @@ RUN apt-get update && apt-get install -y \
   alsa-utils \
   gstreamer1.0-alsa \
   gstreamer1.0-plugins-bad \
+  haproxy \
   mopidy-spotify \
   mopidy-soundcloud && rm -rf /var/lib/apt/lists/*
+
+# Enable haproxy
+RUN echo 'ENABLED=1' >> /etc/default/haproxy
 
 # Set npm
 RUN npm config set unsafe-perm true
@@ -45,6 +49,9 @@ RUN pip install mopidy-gmusic Mopidy-YouTube mopidy-musicbox-webclient
 
 # Save source folder
 RUN printf "%s\n" "${PWD##}" > SOURCEFOLDER
+
+# Deploy haproxy config
+COPY "$SOURCEFOLDER/Dockerbin/haproxy.cfg" /etc/haproxy/haproxy.cfg
 
 # Move to app dir
 WORKDIR /usr/src/app

--- a/README.md
+++ b/README.md
@@ -28,11 +28,12 @@ please refer to [this link](https://github.com/resin-io-playground/boombeastic/b
 - add the _resin remote_ to your local workspace using the useful shortcut in the dashboard UI ![remoteadd](https://raw.githubusercontent.com/resin-io-playground/boombeastic/master/docs/gitresinremote.png)
 - `git push resin master`
 - see the magic happening, your device is getting updated Over-The-Air!
+- after the OTA is completed, you should be able to point your browser to `<boombeasticIP>:80` (get the device IP from the resin dashboard)
+- you can use any MPD client pointing it at `<boombeasticIP>:6680` (the port can be changed using `MOPIDY_MPD_PORT` env var)
 
 ## Configure via [environment variables](https://docs.resin.io/management/env-vars/)
 Variable Name | Default | Description
 ------------ | ------------- | -------------
-MOPIDY_HTTP_PORT | `8080` | the port on which expose the web UI
 MOPIDY_MPD_PORT | `6680` | the port on which expose the MPD service
 MOPIDY_AUDIO_MIXER_VOLUME | `50` | the default volume
 MOPIDY_GMUSIC_ENABLED | `false` | if set `true` loads the [Google Play Music extension](https://github.com/mopidy/mopidy-gmusic)

--- a/app/start.sh
+++ b/app/start.sh
@@ -12,6 +12,9 @@ mkdir /data/mopidy/local  >/dev/null 2>&1 || true
 mkdir /data/mopidy/media  >/dev/null 2>&1 || true
 mkdir /data/mopidy/playlists  >/dev/null 2>&1 || true
 
+# Start haproxy
+service haproxy start >/dev/null 2>&1 || true
+
 while true; do
     node /usr/src/app/index.js
 done


### PR DESCRIPTION
this way the boombeastic can be controlled remotely via public URL 