### PR TITLE
Only install build deps temporarily where they're needed

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -4,16 +4,7 @@ FROM resin/%%RESIN_MACHINE_NAME%%-node:7
 RUN wget -q -O - https://apt.mopidy.com/mopidy.gpg | apt-key add - &&  \
 wget -q -O /etc/apt/sources.list.d/mopidy.list https://apt.mopidy.com/jessie.list && \
 apt-get update && apt-get install -yq --no-install-recommends \
-  python-dev \
-  python-pip \
-  git \
-  autoconf \
-  automake \
   libtool \
-  libdaemon-dev \
-  libasound2-dev \
-  libpopt-dev \
-  libconfig-dev \
   avahi-daemon \
   libavahi-client-dev \
   libnss-mdns \
@@ -33,18 +24,24 @@ apt-get update && apt-get install -yq --no-install-recommends \
   hostapd \
   iproute2 \
   iw \
-  libdbus-1-dev \
-  libexpat-dev \
   rfkill && apt-get clean && rm -rf /var/lib/apt/lists/* && \
 echo 'ENABLED=1' >> /etc/default/haproxy
 
 # Update setup-tools and install mopidy extensions
-RUN pip install packaging pyparsing setuptools youtube-dl \
+RUN apt-get update \
+  && apt-get install -yq --no-install-recommends \
+    python-dev \
+    python-pip \
+  && pip install packaging pyparsing setuptools youtube-dl \
   && pip install \
     mopidy-gmusic \
     Mopidy-YouTube \
     mopidy-musicbox-webclient \
-    Mopidy-Local-SQLite
+    Mopidy-Local-SQLite \
+  && apt-get purge \
+    python-dev \
+    python-pip \
+  && apt-get autoremove && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Deploy haproxy config
 COPY ./Dockerbin/haproxy.cfg /etc/haproxy/haproxy.cfg
@@ -80,10 +77,32 @@ COPY ./app ./
 RUN ./node_modules/.bin/coffee -c ./src
 
 # Install shairport
-RUN git clone https://github.com/mikebrady/shairport-sync.git shairport-sync --depth 1 \
+RUN apt-get update \
+  && apt-get install -yq --no-install-recommends \
+    autoconf \
+    automake \
+    git \
+    libdaemon-dev \
+    libasound2-dev \
+    libpopt-dev \
+    libconfig-dev \
+    libdbus-1-dev \
+    libexpat-dev \
+  && git clone https://github.com/mikebrady/shairport-sync.git shairport-sync --depth 1 \
   && cd shairport-sync && autoreconf -i -f \
   && ./configure --with-alsa --with-avahi --with-ssl=openssl --with-metadata --with-systemd \
-  && make install && cd ../ && rm -rf shairport-sync
+  && make install && cd ../ && rm -rf shairport-sync \
+  && apt-get purge \
+    autoconf \
+    automake \
+    git \
+    libdaemon-dev \
+    libasound2-dev \
+    libpopt-dev \
+    libconfig-dev \
+    libdbus-1-dev \
+    libexpat-dev \
+  && apt-get autoremove && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Disable haproxy and mopidy services - we will manually start it later
 RUN systemctl disable haproxy mopidy shairport-sync


### PR DESCRIPTION
This reduces the built image size by 27.3 MB, from 680.7 MB to 653.4 MB - I haven't had a chance to test if it actually works on a boombeastic yet though